### PR TITLE
Postfix: Allow postfix user to read the main.cf file

### DIFF
--- a/sail/blueprints.py
+++ b/sail/blueprints.py
@@ -237,6 +237,7 @@ def _bp_postfix(data):
 		c.run('debconf-set-selections <<< \'postfix postfix/relayhost string %s\'' % relay_host)
 		c.run(wait + 'apt update && DEBIAN_FRONTEND=noninteractive apt install -y postfix libsasl2-modules', timeout=300)
 		c.run('usermod -a -G mail www-data', warn=True)
+		c.run('usermod -a -G mail postfix', warn=True)
 
 	click.echo('- Configuring postfix')
 


### PR DESCRIPTION
It seems as if in some cases the sendmail agent, which runs as the postfix user, attempts to read the main.cf configuration file, and fatals out if unsuccessful.

This PR adds the postfix user to the mail group on install, to make sure it has the necessary permissions to do so.