### PR TITLE
Add a default.yaml blueprint

### DIFF
--- a/sail/blueprints.py
+++ b/sail/blueprints.py
@@ -13,7 +13,7 @@ import invoke
 
 @click.argument('path', nargs=-1, required=True)
 @cli.command(context_settings=dict(ignore_unknown_options=True))
-def blueprint(path):
+def blueprint(path, doing_init=False):
 	'''Run a blueprint file against your application'''
 	config = util.config()
 
@@ -131,7 +131,9 @@ def blueprint(path):
 		elif section == 'apt':
 			_bp_apt(data)
 
-	util.success('Blueprint applied successfully')
+	# Don't show success during provision
+	if not doing_init:
+		util.success('Blueprint applied successfully')
 
 def _bp_apt(items):
 	c = util.connection()

--- a/sail/blueprints/default.yaml
+++ b/sail/blueprints/default.yaml
@@ -1,0 +1,19 @@
+---
+version: 1
+
+# Install plugins from the WordPress.org repo or custom sources.
+# All plugins will be activated after all of them are installed.
+plugins:
+  surge: latest
+
+# Configure and launch a fail2ban service on this server. Several jails are
+# available by default:
+# - wordpress-auth: ban failed login attempts
+# - wordpress-auth-long: longer-term ban for really persistent bots
+# - wordpress-pingback: protect against wp.pingback attacks
+# - sshd: ban failed ssh attempts
+fail2ban:
+  wordpress-auth
+  wordpress-auth-long
+  wordpress-pingback
+  sshd

--- a/sail/provision.py
+++ b/sail/provision.py
@@ -1,4 +1,4 @@
-from sail import cli, util, deploy, domains, cron, __version__
+from sail import cli, util, deploy, domains, blueprints, cron, __version__
 
 import sail
 import json
@@ -22,9 +22,10 @@ from prettytable import PrettyTable
 @click.option('--email', help='The admin e-mail address. You can set the default e-mail address with: sail config email <email>')
 @click.option('--namespace', default='default', help='The namespace to use for the new application')
 @click.option('--environment', help='Initialize the application into an existing environment')
+@click.option('--blueprint', 'blueprint', default='default.yaml', help='Apply a blueprint after init, defaults to: default.yaml')
 @click.option('--force', '-f', is_flag=True)
 @click.pass_context
-def init(ctx, provider_token, email, size, region, force, namespace, environment):
+def init(ctx, provider_token, email, size, region, force, namespace, environment, blueprint):
 	'''Initialize and provision a new project'''
 	root = util.find_root()
 
@@ -143,6 +144,13 @@ def init(ctx, provider_token, email, size, region, force, namespace, environment
 
 	# Add the default WP cron schedule.
 	ctx.invoke(cron.add, schedule='*/5', command=('wp cron event run --due-now',), quiet=True)
+
+	# Run a default blueprint
+	if blueprint and blueprint != 'no' and blueprint != 'none':
+		try:
+			ctx.invoke(blueprints.blueprint, path=[blueprint], doing_init=True)
+		except:
+			util.item('Could not apply blueprint')
 
 	# Download files from production
 	ctx.invoke(deploy.download, yes=True, doing_init=True)

--- a/sail/tests/end2end.py
+++ b/sail/tests/end2end.py
@@ -61,6 +61,10 @@ class TestEnd2End(unittest.TestCase):
 		self.assertEqual(result.exit_code, 0)
 		self.assertIn('The ship has sailed!', result.output)
 
+		# Default bp applied.
+		self.assertIn('Applying blueprint: default.yaml', result.output)
+		self.assertNotIn('Could not apply blueprint', result.output)
+
 	def test_002_wp_home(self):
 		result = self.runner.invoke(cli, ['wp', 'option', 'get', 'home'])
 		self.assertEqual(result.exit_code, 0)
@@ -409,12 +413,7 @@ class TestEnd2End(unittest.TestCase):
 
 	@unittest.skipIf(work_in_progress, 'Work in progress!')
 	def test_012_blueprint_fail2ban(self):
-		result = self.runner.invoke(cli, ['blueprint', 'test_fail2ban.yaml'])
-		self.assertEqual(result.exit_code, 0)
-		self.assertIn('Installing fail2ban', result.output)
-		self.assertIn('Configuring fail2ban rules', result.output)
-
-		# Running again should not install.
+		# Fail2ban should be already installed via default.yaml
 		result = self.runner.invoke(cli, ['blueprint', 'test_fail2ban.yaml'])
 		self.assertEqual(result.exit_code, 0)
 		self.assertNotIn('Installing fail2ban', result.output)


### PR DESCRIPTION
This adds a --blueprint flag to init, which defaults to default.yaml. The default blueprint installs the [Surge](https://wordpress.org/plugins/surge/) page caching plugin, and configures fail2ban.

You can force an empty WordPress install with `--blueprint=no` or use a custom blueprint.