### PR TITLE
chore: bump pyyaml to 6.0.2 to support py3.13 build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "packaging==24.1",
     "paramiko==3.4.0",
     "python-digitalocean==1.17.0",
-    "PyYAML==6.0.1",
+    "PyYAML==6.0.2",
     "requests==2.32.3",
     "tldextract==5.1.2",
 ]


### PR DESCRIPTION
bump pyyaml to 6.0.2 to support py3.13 build

see 6.0.2 release in here, https://github.com/yaml/pyyaml/releases/tag/6.0.2

relates to https://github.com/Homebrew/homebrew-core/pull/194175